### PR TITLE
wazo-tox: add the ability to the the integration_test_timeout

### DIFF
--- a/roles/wazo-tox/tasks/main.yaml
+++ b/roles/wazo-tox/tasks/main.yaml
@@ -35,6 +35,11 @@
       WAZO_TEST_DOCKER_OVERRIDE_EXTRA: "{{ docker_sibling_results.file }}"
   when: docker_install_siblings
 
+- name: Set the INTEGRATION_TEST_TIMEOUT environment variable
+  set_fact:
+    integration_test_timeout:
+      INTEGRATION_TEST_TIMEOUT: '{{ integration_test_timeout | default(omit) }}'
+
 - name: Emit docker compose override file
   debug:
     msg: "Docker compose override file contents: {{ docker_sibling_results.contents }}"
@@ -48,5 +53,5 @@
   args:
     chdir: "{{ zuul_work_dir }}"
   # yamllint disable-line rule:line-length
-  environment: "{{ tox_environment|combine(docker_compose_override_env|default({}))|combine(tox_constraints_env|default({})) }}"
+  environment: "{{ tox_environment|combine(docker_compose_override_env|default({}))|combine(tox_constraints_env|default({}))|combine(integration_test_timeout|default({})) }}"
   command: "{{ tox_executable }} -e{{ tox_envlist }} {{ tox_extra_args }}"


### PR DESCRIPTION
setting this variable should add the INTEGRATION_TEST_TIME environment variable