### PR TITLE
fix mount path for docker image

### DIFF
--- a/roles/wazo-tox/library/docker_sibling_packages.py
+++ b/roles/wazo-tox/library/docker_sibling_packages.py
@@ -58,7 +58,7 @@ def main():
         package = get_package_name(tox_python, root)
         volumes.add(
             "{root}/{package}:"
-            "/usr/local/lib/python3.7/site-packages/{package}".format(
+            "/opt/venv/lib/python3.7/site-packages/{package}".format(
                 root=os.path.realpath(root), package=package
             ))
 


### PR DESCRIPTION
reason: all wazo-platform image have been migrated to use virtualenv